### PR TITLE
test: add PostService unit test & jacoco report (#8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '4.0.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.cmc'
@@ -40,4 +41,18 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacoco {
+	toolVersion = "0.8.11"
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	reports {
+		html.required = true
+	}
 }

--- a/src/test/java/com/cmc/board/post/service/PostServiceTest.java
+++ b/src/test/java/com/cmc/board/post/service/PostServiceTest.java
@@ -1,0 +1,48 @@
+package com.cmc.board.post.service;
+
+import com.cmc.board.post.domain.Post;
+import com.cmc.board.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PostService 유닛 테스트
+ *
+ * BDD 스타일 (Given / When / Then)
+ */
+@SpringBootTest
+class PostServiceTest {
+
+    @Autowired
+    private PostService postService;
+
+    @Test
+    @DisplayName("게시글을 생성하면 정상적으로 저장된다")
+    void createPost_success() {
+        // ===== Given =====
+        User user = new User(
+                "test@test.com",
+                "password",
+                "USER",
+                LocalDateTime.now()
+        );
+
+        String title = "테스트 게시글 제목";
+        String content = "테스트 게시글 내용";
+
+        // ===== When =====
+        Post post = postService.create(user, title, content);
+
+        // ===== Then =====
+        assertThat(post.getId()).isNotNull();
+        assertThat(post.getTitle()).isEqualTo(title);
+        assertThat(post.getContent()).isEqualTo(content);
+        assertThat(post.getAuthor()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Step 4. 유닛 테스트 (BDD)

### 작업 내용
- PostService 단위 테스트 작성 (Given-When-Then)
- JUnit 기반 테스트 실행
- JaCoCo 테스트 커버리지 리포트 생성

### 테스트 결과
- 테스트 2건 실행 / 실패 0건
- 성공률 100%
<img width="1072" height="530" alt="image" src="https://github.com/user-attachments/assets/8d013325-df31-440b-b0a7-373a040230fb" />


### 관련 이슈
- closes #8 