### PR TITLE
feat: render post list page with thymeleaf

### DIFF
--- a/src/main/java/com/cmc/board/post/controller/PostViewController.java
+++ b/src/main/java/com/cmc/board/post/controller/PostViewController.java
@@ -1,16 +1,26 @@
 package com.cmc.board.post.controller;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/posts")
 public class PostViewController {
 
     @GetMapping
-    public String list() {
+    public String list(Model model) {
+        // ✅ 임시 데이터(컴파일 100% 통과)
+        model.addAttribute("posts", List.of(
+                new SimplePost(1L, "첫 번째 글"),
+                new SimplePost(2L, "두 번째 글")
+        ));
         return "post/list";
     }
-}
 
+    // ✅ 화면용 임시 DTO (내부 클래스)
+    public record SimplePost(Long id, String title) {}
+}

--- a/src/main/resources/templates/post/list.html
+++ b/src/main/resources/templates/post/list.html
@@ -4,17 +4,22 @@
     <meta charset="UTF-8">
     <title>게시글 목록</title>
 
-    <!-- Bootstrap CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 
 <body class="container py-4">
-<h1 class="mb-3">게시글 목록</h1>
+<h1 class="mb-4">게시글 목록</h1>
 
-<div class="alert alert-success">
-    🎉 화면 연결 성공!
-</div>
+<a href="/posts/new" class="btn btn-primary mb-3">글 작성</a>
 
-<a href="/posts/new" class="btn btn-primary">글 작성</a>
+<ul class="list-group">
+    <li class="list-group-item"
+        th:each="post : ${posts}">
+        <a th:href="@{/posts/{id}(id=${post.id})}"
+           th:text="${post.title}">
+            게시글 제목
+        </a>
+    </li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
 feat: 게시글 목록 화면 구현 #19 
<img width="783" height="361" alt="image" src="https://github.com/user-attachments/assets/9f33c4e9-fa68-412c-a302-ccc9fbe0dfc9" />


## 작업 내용
- Thymeleaf를 사용한 게시글 목록 화면 구현
- /posts 경로에서 게시글 목록 UI 렌더링
- Bootstrap CDN 적용

## 비고
- 현재 임시 데이터를 사용하여 화면 흐름을 우선 구현
- 이후 상세 페이지 및 실제 서비스 로직 연동 예정