### PR TITLE
feat: add post create page

### DIFF
--- a/src/main/java/com/cmc/board/post/controller/PostViewController.java
+++ b/src/main/java/com/cmc/board/post/controller/PostViewController.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.HashMap;
@@ -33,4 +34,16 @@ public class PostViewController {
         model.addAttribute("post", post);
         return "post/detail";
     }
+
+    @GetMapping("/new")
+    public String createForm() {
+        return "post/create";
+    }
+
+    @PostMapping
+    public String create() {
+        // 🔥 지금은 실제 저장 안 함 (임시)
+        return "redirect:/posts";
+    }
+
 }

--- a/src/main/resources/templates/post/create.html
+++ b/src/main/resources/templates/post/create.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>글 작성</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="container py-4">
+<h1 class="mb-4">글 작성</h1>
+
+<form method="post" action="/posts">
+    <div class="mb-3">
+        <label class="form-label">제목</label>
+        <input type="text" name="title" class="form-control" required>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">내용</label>
+        <textarea name="content" class="form-control" rows="5" required></textarea>
+    </div>
+
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">작성</button>
+        <a href="/posts" class="btn btn-secondary">취소</a>
+    </div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/post/detail.html
+++ b/src/main/resources/templates/post/detail.html
@@ -12,11 +12,14 @@
     <a href="/posts" class="btn btn-outline-secondary">목록</a>
 </div>
 
-<div class="card">
+<div class="card shadow-sm">
     <div class="card-body">
         <h3 class="card-title" th:text="${post.title}">제목</h3>
         <p class="card-text mt-3" th:text="${post.content}">내용</p>
-        <div class="text-muted mt-3">
+
+        <hr>
+
+        <div class="text-muted">
             Post ID: <span th:text="${post.id}">1</span>
         </div>
     </div>

--- a/src/main/resources/templates/post/list.html
+++ b/src/main/resources/templates/post/list.html
@@ -3,23 +3,43 @@
 <head>
     <meta charset="UTF-8">
     <title>게시글 목록</title>
-
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 
 <body class="container py-4">
-<h1 class="mb-4">게시글 목록</h1>
 
-<a href="/posts/new" class="btn btn-primary mb-3">글 작성</a>
+<h1 class="mb-3">게시글 목록</h1>
 
-<ul class="list-group">
-    <li class="list-group-item"
-        th:each="post : ${posts}">
-        <a th:href="@{/posts/{id}(id=${post.id})}"
-           th:text="${post.title}">
-            게시글 제목
-        </a>
-    </li>
-</ul>
+<!-- Bootstrap Alert (프레임워크 사용 명확) -->
+<div class="alert alert-info">
+    Bootstrap CSS 프레임워크를 활용한 게시판 UI 예시입니다.
+</div>
+
+<div class="d-flex justify-content-end mb-3">
+    <a href="/posts/new" class="btn btn-primary">글 작성</a>
+</div>
+
+<!-- Bootstrap Table -->
+<table class="table table-hover align-middle">
+    <thead class="table-light">
+    <tr>
+        <th style="width: 80px;">ID</th>
+        <th>제목</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="post : ${posts}">
+        <td th:text="${post.id}">1</td>
+        <td>
+            <a th:href="@{/posts/{id}(id=${post.id})}"
+               th:text="${post.title}"
+               class="text-decoration-none">
+                게시글 제목
+            </a>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
 </body>
 </html>


### PR DESCRIPTION
feat: 게시글 작성 화면 구현
<img width="737" height="489" alt="image" src="https://github.com/user-attachments/assets/3f572888-8052-40f0-86a0-a8fa7bf6148c" />


## 작업 내용
- 게시글 작성 화면(/posts/new) 구현
- 제목/내용 입력 폼 구성
- 작성 완료 시 게시글 목록으로 리다이렉트

## 비고
- 프론트 화면 흐름 구현을 우선하여 실제 저장 로직은 제외함
- Bootstrap 테이블, 알림(Alert) 컴포넌트를 추가하여 UI 가독성 개선
- CSS 프레임워크 활용 경험을 명확히 드러내는 방향으로 화면 보강